### PR TITLE
Fix dotnet environment

### DIFF
--- a/roles/archlinux/files/zshenv.d/50-dotnet
+++ b/roles/archlinux/files/zshenv.d/50-dotnet
@@ -2,4 +2,9 @@ export DOTNET_ROOT=/usr/share/dotnet
 
 # To resolve conflict between mono and MSBuild
 # Set path to existing sdk
-export MSBuildSDKsPath=$( echo /usr/share/dotnet/sdk/6.*/Sdks );
+# This interferes with projects with different SDK-versions.
+# Remove temporarily, as mono isn't used much anymore
+#export MSBuildSDKsPath=$( echo /usr/share/dotnet/sdk/7.*/Sdks );
+
+# Default to development environment
+export ASPNETCORE_ENVIRONMENT=Development


### PR DESCRIPTION
- Remove env variable to fix mono-conflict. This interferes with normal dotnet applications with different sdks
- Add Development as default environment